### PR TITLE
Add simple NPC support

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -358,6 +358,30 @@ export class Pet extends Entity {
     addConsumable() { return false; }
 }
 
+export class Npc {
+    constructor(config) {
+        this.x = config.x;
+        this.y = config.y;
+        this.width = config.width || config.tileSize || 32;
+        this.height = config.height || config.tileSize || 32;
+        this.image = config.image || null;
+        this.action = config.action || null;
+    }
+
+    render(ctx) {
+        if (this.image) {
+            ctx.drawImage(this.image, this.x, this.y, this.width, this.height);
+        }
+    }
+
+    triggerAction(player) {
+        if (typeof this.action === 'function') {
+            console.log(`NPC 액션 실행: ${this.action.name || 'anonymous'}`);
+            this.action(player);
+        }
+    }
+}
+
 export class Item {
     constructor(x, y, tileSize, name, image) {
         this.id = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : Math.random().toString(36).slice(2);

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -25,6 +25,7 @@ import { StatusEffectsManager } from './statusEffectsManager.js';
 import { MicroItemAIManager } from './microItemAIManager.js';
 import { EffectIconManager } from './effectIconManager.js';
 import { PetManager } from './petManager.js';
+import { NpcManager } from './npcManager.js';
 import { SquadManager } from './squadManager.js';
 import { LaneAssignmentManager } from './laneAssignmentManager.js';
 import { FormationManager } from './formationManager.js';
@@ -73,6 +74,7 @@ export {
     ParasiteManager,
     MicroItemAIManager,
     PetManager,
+    NpcManager,
     EffectIconManager,
     FormationManager,
     EnemyFormationManager,

--- a/src/managers/npcManager.js
+++ b/src/managers/npcManager.js
@@ -1,0 +1,31 @@
+export class NpcManager {
+    constructor() {
+        this.npcs = [];
+    }
+
+    addNpc(npc) {
+        this.npcs.push(npc);
+    }
+
+    _checkCollision(a, b) {
+        return (
+            a.x < b.x + b.width &&
+            a.x + a.width > b.x &&
+            a.y < b.y + b.height &&
+            a.y + a.height > b.y
+        );
+    }
+
+    update(player, ctx = null) {
+        for (const npc of this.npcs) {
+            if (ctx && typeof npc.render === 'function') {
+                npc.render(ctx);
+            }
+            if (player && this._checkCollision(player, npc)) {
+                if (typeof npc.triggerAction === 'function') {
+                    npc.triggerAction(player);
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/npc.test.js
+++ b/tests/unit/npc.test.js
@@ -1,0 +1,15 @@
+import { Npc } from '../../src/entities.js';
+import { NpcManager } from '../../src/managers/npcManager.js';
+import { describe, test, assert } from '../helpers.js';
+
+describe('NPC System', () => {
+    test('action triggers on collision', () => {
+        let called = false;
+        const npc = new Npc({ x: 0, y: 0, width: 10, height: 10, action: () => { called = true; } });
+        const manager = new NpcManager();
+        manager.addNpc(npc);
+        const player = { x: 0, y: 0, width: 10, height: 10 };
+        manager.update(player);
+        assert.ok(called);
+    });
+});


### PR DESCRIPTION
## Summary
- create `Npc` entity for simple interactions
- implement `NpcManager` to manage NPCs and trigger actions on collision
- export the new manager
- test NPC action triggering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68642176c6f48327b04be31d34f8c4b0