### PR TITLE
Implement GuardianManager rule system

### DIFF
--- a/GuardianManager.py
+++ b/GuardianManager.py
@@ -1,0 +1,24 @@
+from exceptions import ImmutableRuleError
+from map_loader import MapLoader
+from test_runner import TestRunner
+
+
+class GuardianManager:
+    """Oversees map loading and testing while enforcing rules."""
+
+    def __init__(self, initial_units_data):
+        print("🛡️ GuardianManager is now monitoring the system. 🛡️\n")
+        self.map_loader = MapLoader()
+        self.test_runner = TestRunner(initial_units_data)
+
+    def start_map_test(self, map_name):
+        try:
+            map_data = self.map_loader.load(map_name)
+            self.test_runner.run_auto_battle()
+            print(f"\n🎉 All rules respected. '{map_name}' test complete.")
+        except ImmutableRuleError as e:
+            print("\n" + "=" * 50)
+            print("🚨 Critical Error: Immutable rule broken! 🚨")
+            print(f"Reason: {e}")
+            print("Halting process until code is fixed.")
+            print("=" * 50)

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,3 @@
+class ImmutableRuleError(Exception):
+    """Raised when an immutable rule in our game is violated."""
+    pass

--- a/map_loader.py
+++ b/map_loader.py
@@ -1,0 +1,24 @@
+import os
+from exceptions import ImmutableRuleError
+
+
+class MapLoader:
+    """Load map resources while enforcing required tiles exist."""
+
+    REQUIRED_TILES = ["wall.png", "floor.png"]
+
+    def __init__(self, map_directory="maps"):
+        self.map_directory = map_directory
+
+    def load(self, map_name):
+        """Load map data after verifying required tiles."""
+        print(f"--- Loading map '{map_name}' ---")
+        map_path = os.path.join(self.map_directory, map_name)
+        for tile in self.REQUIRED_TILES:
+            if not os.path.exists(os.path.join(map_path, tile)):
+                raise ImmutableRuleError(
+                    f"[Rule #1 Violation] Required tile '{tile}' missing in map '{map_name}'."
+                )
+        print("✅ [Rule 1 Passed] All required tiles present.")
+        # Placeholder for real loading logic
+        return {"name": map_name, "data": "Map loaded successfully"}

--- a/maps/sample_map/floor.png
+++ b/maps/sample_map/floor.png
@@ -1,0 +1,1 @@
+placeholder floor

--- a/maps/sample_map/wall.png
+++ b/maps/sample_map/wall.png
@@ -1,0 +1,1 @@
+placeholder wall

--- a/test_runner.py
+++ b/test_runner.py
@@ -1,0 +1,24 @@
+import copy
+from exceptions import ImmutableRuleError
+
+
+class TestRunner:
+    """Run automated tests such as auto battles on a map."""
+
+    def __init__(self, initial_units_data):
+        self.initial_units_data = initial_units_data
+        print("--- TestRunner initialized ---")
+        print(f"Initial units: {self.initial_units_data}")
+
+    def run_auto_battle(self):
+        print("\n--- Running auto battle ---")
+        if not self.initial_units_data:
+            raise ImmutableRuleError("[Rule #2 Violation] No initial unit data!")
+        units = copy.deepcopy(self.initial_units_data)
+        print("✅ [Rule 2 Passed] Cloned clean units for testing")
+        print(f"Units for this test: {units}")
+        # Example mutation during test
+        units[0]["hp"] -= 50
+        print("...battle finished...")
+        print(f"Post-test units: {units}")
+        print("Original units remain:", self.initial_units_data)


### PR DESCRIPTION
## Summary
- add `ImmutableRuleError` to centralize rule violations
- create `MapLoader` with required tile checks
- implement `TestRunner` with deep copy of units
- add `GuardianManager` orchestrator
- provide sample map with required tile placeholders

## Testing
- `python3 - <<'PY'
from GuardianManager import GuardianManager
initial_units = [{"hp": 100}]
manager = GuardianManager(initial_units)
manager.start_map_test('sample_map')
PY
`
- `npm test` *(fails: process did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_686424510f10832783e00a332a0259df