### PR TITLE
Improve loop tester NPC placement on world map

### DIFF
--- a/src/loopMapTesterNPC.js
+++ b/src/loopMapTesterNPC.js
@@ -4,11 +4,15 @@
 import { Npc } from './entities.js';
 import { startAquariumLoopTest } from './events/aquariumLoopTest.js';
 
-export function registerLoopMapTester(npcManager) {
+// 플레이어 근처에 배치할 수 있도록 위치와 이미지를 인자로 받는다
+// 위치와 이미지를 포함해 크기까지 지정할 수 있게 확장한다
+export function registerLoopMapTester(npcManager, options = {}) {
     const npc = new Npc({
-        x: 250,
-        y: 300,
-        image: null, // image asset could be assigned by the game when available
+        x: options.x ?? 250,
+        y: options.y ?? 300,
+        width: options.width ?? options.tileSize ?? 192,
+        height: options.height ?? options.tileSize ?? 192,
+        image: options.image ?? null,
         action: startAquariumLoopTest,
     });
     npcManager.addNpc(npc);

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -1,3 +1,6 @@
+import { NpcManager } from './managers/npcManager.js';
+import { registerLoopMapTester } from './loopMapTesterNPC.js';
+
 export class WorldEngine {
     constructor(game, assets) {
         this.game = game;
@@ -14,6 +17,8 @@ export class WorldEngine {
         this.followPlayer = true;
         // 플레이어 정보는 Game 초기화 이후 setPlayer()로 전달된다
         this.player = null;
+        // 월드맵 NPC들을 관리하기 위한 매니저
+        this.npcManager = new NpcManager();
         this.monsters = [
             {
                 x: this.tileSize * 3,
@@ -40,6 +45,14 @@ export class WorldEngine {
             image: entity?.image || this.assets['player'],
             entity
         };
+        // 테스트용 NPC를 몬스터와 겹치지 않게 플레이어 바로 아래에 배치한다
+        registerLoopMapTester(this.npcManager, {
+            x: this.player.x,
+            y: this.player.y + this.tileSize,
+            width: this.tileSize,
+            height: this.tileSize,
+            image: this.assets['fire_god'],
+        });
     }
 
     update() {
@@ -48,6 +61,8 @@ export class WorldEngine {
         this.handlePlayerMovement();
         this.updateCamera();
         this.checkCollisions();
+        // 플레이어 이동 시 NPC와의 상호작용도 확인한다
+        this.npcManager.update(this.player);
     }
 
     handleResetFollow() {
@@ -182,5 +197,7 @@ export class WorldEngine {
                 ctx.drawImage(monster.image, monster.x, monster.y, monster.width, monster.height);
             }
         });
+        // NPC들도 그리면서 상호작용을 체크한다
+        this.npcManager.update(this.player, ctx);
     }
 }


### PR DESCRIPTION
## Summary
- let loop tester NPC define size when registered
- spawn the NPC below the player with 192x192 fire god sprite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68642d9aa4b083278f2b52bbc6864a92