### PR TITLE
Fix mercenary images in aquarium loop

### DIFF
--- a/src/events/aquariumLoopTest.js
+++ b/src/events/aquariumLoopTest.js
@@ -58,12 +58,14 @@ export function startAquariumLoopTest(game) {
 
     playerParty.forEach((data, idx) => {
         const jobId = jobMap[data.job] || 'warrior';
+        const image = game.assets[jobId] || game.assets.mercenary;
         const merc = game.factory.create('mercenary', {
             x: 0,
             y: 0,
             tileSize,
             groupId: game.playerGroup.id,
-            jobId
+            jobId,
+            image
         });
         game.mercenaryManager.mercenaries.push(merc);
         game.playerGroup.addMember(merc);


### PR DESCRIPTION
## Summary
- pass image property when creating mercenaries for the aquarium loop test so their sprites render correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686494322ee88327b3913fe0eaabb766