### PR TITLE
Implement spectator mode for Aquarium Loop test

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -78,6 +78,7 @@ export class AIArchetype {
     _filterVisibleEnemies(self, enemies) {
         const range = self.stats?.get('visionRange') ?? self.visionRange;
         return (enemies || []).filter(e =>
+            !e.isSpectator &&
             Math.hypot(e.x - self.x, e.y - self.y) < range);
     }
 
@@ -85,6 +86,7 @@ export class AIArchetype {
         let nearest = null;
         let minDist = Infinity;
         for (const e of enemies || []) {
+            if (e.isSpectator) continue;
             const d = Math.hypot(e.x - self.x, e.y - self.y);
             if (d < minDist) {
                 minDist = d;

--- a/src/entities.js
+++ b/src/entities.js
@@ -24,6 +24,7 @@ class Entity {
         this.attackCooldown = 0;
         this.isPlayer = false;
         this.isFriendly = false;
+        this.isSpectator = false; // 전투에 참여하지 않는 관전자 여부
         this.ai = null;
         this.roleAI = null;     // 힐러, 소환사 등 직업 역할 AI
         this.fallbackAI = null; // 무기가 없을 때 사용할 기본 전투 AI

--- a/src/events/aquariumLoopTest.js
+++ b/src/events/aquariumLoopTest.js
@@ -14,6 +14,8 @@ export function startAquariumLoopTest(game) {
 
     player.isVisible = false;
     player.isObserver = true;
+    player.isSpectator = true;
+    if (game.cameraDrag) game.cameraDrag.followPlayer = false;
     console.log('✅ [규칙 4] 플레이어가 관찰자 모드로 전환되었습니다.');
 
     const diceBot = new DiceBot();
@@ -51,7 +53,6 @@ export function startAquariumLoopTest(game) {
         }
         if (game.metaAIManager.groups['player_party']) {
             game.metaAIManager.groups['player_party'].members = [];
-            game.metaAIManager.groups['player_party'].addMember(player);
         }
     }
     if (game.entityManager) {


### PR DESCRIPTION
## Summary
- add `isSpectator` flag to entities
- ignore spectator entities during AI target selection
- enable spectator mode and disable camera follow in `startAquariumLoopTest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864a3b4a1c88327b5f880046a4f9af3