### PR TITLE
Add FACTIONS constants

### DIFF
--- a/src/constants/factions.js
+++ b/src/constants/factions.js
@@ -1,0 +1,4 @@
+export const FACTIONS = {
+    PLAYER: 'player',
+    ENEMY: 'enemy'
+};

--- a/src/events/aquariumLoopAuto.js
+++ b/src/events/aquariumLoopAuto.js
@@ -3,6 +3,7 @@
 
 import { startAquariumLoopTest } from './aquariumLoopTest.js';
 import { BattleRecorder } from '../managers/battleRecorder.js';
+import { FACTIONS } from '../constants/factions.js';
 
 export function startAquariumBattleLoop(game, { rounds = Infinity, onRoundComplete } = {}) {
     let currentRound = 0;
@@ -44,7 +45,7 @@ export function startAquariumBattleLoop(game, { rounds = Infinity, onRoundComple
         const enemiesAlive = monsterManager.monsters.filter(m => m.hp > 0);
         if (alliesAlive.length === 0 || enemiesAlive.length === 0) {
             running = false;
-            const winner = alliesAlive.length > 0 ? 'player' : 'enemy';
+            const winner = alliesAlive.length > 0 ? FACTIONS.PLAYER : FACTIONS.ENEMY;
             const survivors = (alliesAlive.length > 0 ? alliesAlive : enemiesAlive).length;
             const report = game.battleRecorder.endBattle({ winner, survivors });
             report.round = currentRound;

--- a/src/managers/rlObserver.js
+++ b/src/managers/rlObserver.js
@@ -2,6 +2,7 @@
 // Observes battle rounds to track TensorFlow predictions and accuracy.
 import { RLManager } from './rlManager.js';
 import { memoryDB } from '../persistence/MemoryDB.js';
+import { FACTIONS } from '../constants/factions.js';
 
 export class RLObserver {
     constructor(eventManager) {
@@ -52,9 +53,9 @@ export class RLObserver {
         const features = this.buildFeatures(playerInfo, enemyInfo);
         const res = await this.rlManager.requestPrediction(features);
         if (Array.isArray(res) && res.length >= 2) {
-            this.prediction = res[0] > res[1] ? 'player' : 'enemy';
+            this.prediction = res[0] > res[1] ? FACTIONS.PLAYER : FACTIONS.ENEMY;
         } else {
-            this.prediction = Math.random() < 0.5 ? 'player' : 'enemy';
+            this.prediction = Math.random() < 0.5 ? FACTIONS.PLAYER : FACTIONS.ENEMY;
         }
         this.render();
     }
@@ -77,8 +78,9 @@ export class RLObserver {
     render() {
         if (!this.content) return;
         const acc = this.stats.total ? ((this.stats.correct / this.stats.total) * 100).toFixed(1) : '0';
+        const pred = this.prediction ? (this.prediction === FACTIONS.ENEMY ? 'ENEMY' : this.prediction) : '-';
         this.content.innerHTML =
-            `<div>예측 승자: ${this.prediction ?? '-'}</div>` +
+            `<div>예측 승자: ${pred}</div>` +
             `<div>적중률: ${acc}%</div>` +
             `<div>잘했어요 점수: ${this.stats.score}</div>`;
     }

--- a/tests/unit/rlObserver.test.js
+++ b/tests/unit/rlObserver.test.js
@@ -1,5 +1,6 @@
 import { EventManager } from '../../src/managers/eventManager.js';
 import RLObserver from '../../src/managers/rlObserver.js';
+import { FACTIONS } from '../../src/constants/factions.js';
 import { describe, test, assert } from '../helpers.js';
 
 describe('RLObserver', () => {
@@ -9,7 +10,7 @@ describe('RLObserver', () => {
         await observer.init();
         observer.rlManager.requestPrediction = async () => [0.7, 0.3];
         ev.publish('battle_round_start', { round: 1, playerInfo: [{}], enemyInfo: [{}] });
-        ev.publish('battle_round_complete', { round: 1, winner: 'player' });
+        ev.publish('battle_round_complete', { round: 1, winner: FACTIONS.PLAYER });
         assert.strictEqual(observer.stats.correct, 1);
         assert.strictEqual(observer.stats.total, 1);
         assert.strictEqual(observer.stats.score, 50);


### PR DESCRIPTION
## Summary
- define `FACTIONS` constants for Player and Enemy sides
- use the new constants in RLObserver and AquariumLoop loop
- adjust RLObserver test to reference constants

## Testing
- `node run-tests.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6864be4ea5a88327ab503b0d7e98dbbf