### PR TITLE
Add TensorFlow input pathway

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 * **TensorFlow 길찾기 토글:** `config/gameSettings.js`의 `ENABLE_TENSORFLOW_PATHING`을 활성화하면 학습된 모델을 이용해 보다 자연스러운 경로를 계산합니다. 기본값은 꺼져 있으며, 모델 파일이 없을 경우 자동으로 기존 BFS 로직을 사용합니다.
 * **평판 시스템 토글:** `config/gameSettings.js`의 `ENABLE_REPUTATION_SYSTEM` 값을 false로 설정하면 평판 기록과 모델 로드를 생략하여 성능을 높일 수 있습니다.
 * **실시간 학습 매니저:** `RLManager`가 전투 로그를 Web Worker로 전송해 TensorFlow 모델을 실시간으로 학습하며 예측 기능을 제공합니다.
+* **TensorFlow 입력 매니저:** `RLInputManager`가 학습된 모델의 예측을 받아 AI의 행동 결정에 반영합니다.
 
 ## 개발 원칙
 

--- a/src/ai/engines/DecisionEngine.js
+++ b/src/ai/engines/DecisionEngine.js
@@ -2,13 +2,25 @@ import { MistakeEngine } from './MistakeEngine.js';
 import { MbtiEngine } from './MbtiEngine.js';
 
 export class DecisionEngine {
-    constructor(eventManager = null) {
+    constructor(eventManager = null, rlInputManager = null) {
         this.mbtiEngine = new MbtiEngine(eventManager);
         this.mistakeEngine = new MistakeEngine();
+        this.rlInputManager = rlInputManager;
     }
 
-    decideFinalAction(entity, context, strategy = 'AGGRESSIVE') {
+    async decideFinalAction(entity, context, strategy = 'AGGRESSIVE') {
         let baseAction = entity.ai?.decideAction(entity, context) || { type: 'idle' };
+
+        if (this.rlInputManager) {
+            try {
+                const rlAction = await this.rlInputManager.getAction(entity, context);
+                if (rlAction) {
+                    baseAction = rlAction;
+                }
+            } catch (err) {
+                console.warn('[DecisionEngine] RLInputManager error:', err);
+            }
+        }
 
         if (strategy === 'DEFENSIVE') {
             const player = context.player;

--- a/src/managers/AIManager.js
+++ b/src/managers/AIManager.js
@@ -1,10 +1,12 @@
 import { DecisionEngine } from '../ai/engines/DecisionEngine.js';
+import { RLInputManager } from './rlInputManager.js';
 
 export class AIManager {
-    constructor(eventManager, squadManager) {
+    constructor(eventManager, squadManager, rlManager = null) {
         this.eventManager = eventManager;
         this.squadManager = squadManager;
-        this.decisionEngine = new DecisionEngine(eventManager);
+        const rlInput = rlManager ? new RLInputManager(rlManager) : null;
+        this.decisionEngine = new DecisionEngine(eventManager, rlInput);
         this.aiEntities = new Set();
     }
 
@@ -18,12 +20,12 @@ export class AIManager {
         this.aiEntities.delete(entity);
     }
 
-    update(context) {
+    async update(context) {
         for (const entity of this.aiEntities) {
             if (entity.hp <= 0 || !entity.ai) continue;
             const squad = this.squadManager?.getSquadForMerc(entity.id);
             const strategy = squad ? squad.strategy : 'AGGRESSIVE';
-            const action = this.decisionEngine.decideFinalAction(entity, context, strategy);
+            const action = await this.decisionEngine.decideFinalAction(entity, context, strategy);
             this.executeAction(entity, action, context);
         }
     }

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -45,6 +45,7 @@ import { BattleRecorder } from './battleRecorder.js';
 import { RLManager } from './rlManager.js';
 import { RLUIManager } from './rlUIManager.js';
 import { RLObserver } from './rlObserver.js';
+import { RLInputManager } from './rlInputManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -101,4 +102,5 @@ export {
     RLManager,
     RLUIManager,
     RLObserver,
+    RLInputManager,
 };

--- a/src/managers/rlInputManager.js
+++ b/src/managers/rlInputManager.js
@@ -1,0 +1,37 @@
+export class RLInputManager {
+    /**
+     * @param {import('./rlManager.js').RLManager} rlManager
+     */
+    constructor(rlManager) {
+        this.rlManager = rlManager;
+    }
+
+    buildFeatures(entity, context) {
+        const nearest = context.enemies && context.enemies[0];
+        const dist = nearest ? Math.hypot(nearest.x - entity.x, nearest.y - entity.y) : 0;
+        return [
+            entity.hp / (entity.maxHp || 1),
+            dist,
+            (context.enemies ? context.enemies.length : 0)
+        ];
+    }
+
+    async getAction(entity, context) {
+        if (!this.rlManager) return null;
+        const features = this.buildFeatures(entity, context);
+        const prediction = await this.rlManager.requestPrediction(features);
+        return this.mapPrediction(prediction, context);
+    }
+
+    mapPrediction(prediction, context) {
+        if (!Array.isArray(prediction)) return null;
+        const [moveScore, attackScore] = prediction;
+        if (attackScore > moveScore && context.enemies && context.enemies.length) {
+            return { type: 'attack', target: context.enemies[0] };
+        }
+        if (context.player) {
+            return { type: 'move', target: context.player };
+        }
+        return null;
+    }
+}

--- a/tests/integration/bardSkills.integration.test.js
+++ b/tests/integration/bardSkills.integration.test.js
@@ -7,7 +7,7 @@ import { SKILLS } from '../../src/data/skills.js';
 // Bard should sequentially use both hymns when available
 
 describe('Integration', () => {
-  test('bard mercenary uses guardian and courage hymns', () => {
+  test('bard mercenary uses guardian and courage hymns', async () => {
     const assets = { player:{}, mercenary:{}, monster:{} };
     const factory = new CharacterFactory(assets);
     const eventManager = new EventManager();
@@ -55,7 +55,7 @@ describe('Integration', () => {
     };
 
     // first update - expect guardian hymn
-    aiManager.update(context);
+    await aiManager.update(context);
     assert.strictEqual(actions[0].skillId, SKILLS.guardian_hymn.id, 'first action should be guardian hymn');
 
     // simulate shield effect so bard picks courage hymn next
@@ -63,7 +63,7 @@ describe('Integration', () => {
     bard.effects.push({ id: 'shield' });
 
     actions.length = 0;
-    aiManager.update(context);
+    await aiManager.update(context);
     assert.strictEqual(actions[0].skillId, SKILLS.courage_hymn.id, 'second action should be courage hymn');
   });
 });

--- a/tests/integration/mercenaryAI.integration.test.js
+++ b/tests/integration/mercenaryAI.integration.test.js
@@ -8,7 +8,7 @@ import { HealerAI } from '../../src/ai.js';
 // 통합 테스트: 용병들이 자신의 스킬/무기 AI에 따라 행동하는지 확인
 
 describe('Integration', () => {
-  test('mercenary AIs act according to their roles and weapons', () => {
+  test('mercenary AIs act according to their roles and weapons', async () => {
     const assets = { player:{}, mercenary:{}, monster:{} };
     const factory = new CharacterFactory(assets);
     const eventManager = new EventManager();
@@ -61,7 +61,7 @@ describe('Integration', () => {
       speechBubbleManager: { addBubble(){} },
     };
 
-    aiManager.update(context);
+    await aiManager.update(context);
 
     assert.ok(actions[archer.id] && actions[archer.id].type !== 'idle', 'archer should act');
     assert.strictEqual(actions[healer.id].type, 'skill', 'healer should attempt to heal');

--- a/tests/unit/aiGroupStrategy.test.js
+++ b/tests/unit/aiGroupStrategy.test.js
@@ -13,7 +13,7 @@ test('setGroupStrategy updates strategy', () => {
     assert.strictEqual(group.strategy, STRATEGY.IDLE);
 });
 
-test('IDLE strategy prevents movement', () => {
+test('IDLE strategy prevents movement', async () => {
     const em = new EventManager();
     const aiManager = new MetaAIManager(em);
     const mapManager = { tileSize: 1, isWallAt: () => false };
@@ -26,7 +26,7 @@ test('IDLE strategy prevents movement', () => {
     group.addMember(self);
     enemyGroup.addMember(enemy);
     const context = { player, mapManager, pathfindingManager, eventManager: em };
-    aiManager.update(context);
+    await aiManager.update(context);
     assert.strictEqual(self.x, 0);
     assert.strictEqual(self.y, 0);
 });

--- a/tests/unit/attackSpeed.test.js
+++ b/tests/unit/attackSpeed.test.js
@@ -5,7 +5,7 @@ import { describe, test, assert } from '../helpers.js';
 
 describe('AI', () => {
 
-test('공격 속도가 빠른 유닛이 먼저 공격', () => {
+test('공격 속도가 빠른 유닛이 먼저 공격', async () => {
     const em = new EventManager();
     const aiManager = new MetaAIManager(em);
     const mapManager = { tileSize: 1, isWallAt: () => false };
@@ -35,7 +35,7 @@ test('공격 속도가 빠른 유닛이 먼저 공격', () => {
     em.subscribe('entity_attack', d => order.push(d.attacker.id));
 
     const context = { player, mapManager, pathfindingManager, eventManager: em, monsterManager:{monsters:[]}, mercenaryManager:{mercenaries:[]} };
-    aiManager.update(context);
+    await aiManager.update(context);
 
     assert.strictEqual(order[0], 'fast');
 });

--- a/tests/unit/embargo.test.js
+++ b/tests/unit/embargo.test.js
@@ -41,7 +41,7 @@ class AutoPlayerAI extends MeleeAI {
     }
 }
 
-test('차지 어택과 포션 사용 시나리오', () => {
+test('차지 어택과 포션 사용 시나리오', async () => {
     const assets = { player:{}, monster:{}, potion:{}, sword:{}, leather_armor:{}, 'violin-bow':{}, 'plate-armor':{} };
     const mapManager = new MapManager(1);
     const factory = new CharacterFactory(assets);
@@ -95,7 +95,7 @@ test('차지 어택과 포션 사용 시나리오', () => {
     aiManager.groups['player_party'] = playerGroup;
     aiManager.groups['dungeon_monsters'] = monsterGroup;
 
-    aiManager.update(context);
+    await aiManager.update(context);
 
     assert.ok(chargeUsed, '차지 어택이 발동되지 않았습니다');
     assert.ok(player.hp >= 8, '포션 사용 후 HP 값이 올바르지 않습니다');


### PR DESCRIPTION
## Summary
- add RLInputManager for TensorFlow-driven actions
- hook RLInputManager into DecisionEngine and MetaAIManager
- make AI update loops async-aware
- document RLInputManager in README
- update tests for async AI updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864ceae4b108327b18cb6bd54a6ab62