### PR TITLE
Implement random gear for aquarium loop units

### DIFF
--- a/src/events/aquariumLoopTest.js
+++ b/src/events/aquariumLoopTest.js
@@ -5,6 +5,7 @@ import { DiceBot } from '../utils/diceBot.js';
 import { FormationManager } from '../managers/formationManager.js';
 import { EnemyFormationManager } from '../managers/enemyFormationManager.js';
 import { AquariumMapManager } from '../aquariumMap.js';
+import { equipRandomWeapon, addRandomConsumables } from '../utils/aquariumUtils.js';
 
 export function startAquariumLoopTest(game) {
     const player = game.gameState.player;
@@ -91,6 +92,8 @@ export function startAquariumLoopTest(game) {
             image
         });
         merc.equipmentRenderManager = game.equipmentRenderManager;
+        equipRandomWeapon(merc, game.itemFactory, game.equipmentManager);
+        addRandomConsumables(merc, 4, game.itemFactory);
         game.mercenaryManager.mercenaries.push(merc);
         game.playerGroup.addMember(merc);
         allyFormation.assign(idx, merc.id);
@@ -112,6 +115,8 @@ export function startAquariumLoopTest(game) {
         enemyMerc.isFriendly = false;
         enemyMerc.direction = -1;
         enemyMerc.equipmentRenderManager = game.equipmentRenderManager;
+        equipRandomWeapon(enemyMerc, game.itemFactory, game.equipmentManager);
+        addRandomConsumables(enemyMerc, 4, game.itemFactory);
         game.monsterManager.monsters.push(enemyMerc);
         game.monsterGroup.addMember(enemyMerc);
         enemyFormation.assign(idx, enemyMerc.id);

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -2,7 +2,7 @@
 // Manages patches and features placed on the Aquarium map
 import { TRAITS } from '../data/traits.js';
 import { EquipmentManager } from './equipmentManager.js';
-import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
+import { adjustMonsterStatsForAquarium, addRandomConsumables } from '../utils/aquariumUtils.js';
 export class AquariumManager {
     constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory, vfxManager = null, traitManager = null) {
         this.eventManager = eventManager;
@@ -115,6 +115,7 @@ export class AquariumManager {
                             shieldSpawned = true;
                         }
                     }
+                    addRandomConsumables(monster, 4, this.itemFactory);
                 }
             }
         }
@@ -160,6 +161,7 @@ export class AquariumManager {
                                 this.equipmentManager.equip(monster, shield, null);
                             }
                         }
+                        addRandomConsumables(monster, 4, this.itemFactory);
                     }
                 }
                 // --- 여기까지 ---

--- a/src/utils/aquariumUtils.js
+++ b/src/utils/aquariumUtils.js
@@ -32,3 +32,52 @@ export function adjustMonsterStatsForAquarium(baseStats = {}) {
 
     return adjusted;
 }
+
+// --- New Helper Functions for Aquarium Loop ---
+import { ITEMS } from '../data/items.js';
+
+// Precompute lists so random selection is fast
+export const ALL_WEAPON_IDS = [
+    'short_sword', 'long_bow', 'estoc', 'axe', 'mace', 'staff',
+    'spear', 'scythe', 'whip', 'dagger', 'violin_bow'
+];
+
+export const CONSUMABLE_IDS = Object.keys(ITEMS).filter(
+    id => ITEMS[id].type === 'consumable'
+);
+
+/**
+ * Equip a character with a random weapon and optionally a shield.
+ * @param {Entity} entity - Character receiving the weapon
+ * @param {ItemFactory} itemFactory - Factory used to create items
+ * @param {EquipmentManager} equipmentManager - Manager handling equipment slots
+ */
+export function equipRandomWeapon(entity, itemFactory, equipmentManager) {
+    const id = ALL_WEAPON_IDS[Math.floor(Math.random() * ALL_WEAPON_IDS.length)];
+    const weapon = itemFactory.create(id, 0, 0, 1);
+    if (!weapon) return;
+    equipmentManager.equip(entity, weapon, null);
+
+    const tags = weapon.tags || [];
+    const isMelee = tags.includes('melee') && !tags.includes('ranged');
+    const excluded = tags.includes('spear') || tags.includes('scythe');
+    if (isMelee && !excluded && Math.random() < 0.5) {
+        const shield = itemFactory.create('shield_basic', 0, 0, 1);
+        if (shield) equipmentManager.equip(entity, shield, null);
+    }
+}
+
+/**
+ * Fill a character's consumable inventory with random items.
+ *
+ * @param {Entity} entity - Character gaining consumables
+ * @param {number} count - Number of consumables to add
+ * @param {ItemFactory} itemFactory - Factory used to create items
+ */
+export function addRandomConsumables(entity, count, itemFactory) {
+    for (let i = 0; i < count; i++) {
+        const cId = CONSUMABLE_IDS[Math.floor(Math.random() * CONSUMABLE_IDS.length)];
+        const item = itemFactory.create(cId, 0, 0, 1);
+        if (item) entity.addConsumable(item);
+    }
+}


### PR DESCRIPTION
## Summary
- support equipping random weapons and consumables via helpers
- spawn Aquarium loop mercenaries with random weapons and four consumables
- monsters spawned in Aquarium map now gain consumables too

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864efefdf788327871d924816052a55