### PR TITLE
Enable shock weapons and attack items in aquarium loop

### DIFF
--- a/src/data/weapon-skills.js
+++ b/src/data/weapon-skills.js
@@ -77,5 +77,14 @@ export const WEAPON_SKILLS = {
         tags: ['weapon_skill', 'offensive', 'mace'],
         twistedDuration: 2000,
     },
+    thunder_strike: {
+        id: 'thunder_strike',
+        name: '뇌전 일격',
+        description: '대상을 타격하여 감전 상태로 만듭니다.',
+        type: 'active',
+        cooldown: 20,
+        tags: ['weapon_skill', 'offensive', 'stun_baton'],
+        effects: { target: ['shock'] },
+    },
     // 에스톡 레벨 1 (창의 돌진 스킬을 공유)
 };

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -211,6 +211,11 @@ export class MetaAIManager {
                     context.statusEffectsManager?.applyTwisted(action.target, skillData.twistedDuration || 2000);
                     entity.attackCooldown = Math.max(1, Math.round(60 / (entity.attackSpeed || 1)));
                 }
+                if (action.skillId === 'thunder_strike' && context.effectManager && action.target) {
+                    eventManager.publish('entity_attack', { attacker: entity, defender: action.target, skill: skillData });
+                    context.effectManager.addEffect(action.target, 'shock');
+                    entity.attackCooldown = Math.max(1, Math.round(60 / (entity.attackSpeed || 1)));
+                }
 
                 if (context.speechBubbleManager) {
                     context.speechBubbleManager.addBubble(entity, skillData.name);

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -15,7 +15,7 @@ export class AquariumManager {
         this.traitManager = traitManager;
         this.features = [];
         this.equipmentManager = new EquipmentManager(eventManager);
-        this.allWeaponIds = ['short_sword', 'long_bow', 'estoc', 'axe', 'mace', 'staff', 'spear', 'scythe', 'whip', 'dagger', 'violin_bow'];
+        this.allWeaponIds = ['short_sword', 'long_bow', 'estoc', 'axe', 'mace', 'stun_baton', 'staff', 'spear', 'scythe', 'whip', 'dagger', 'violin_bow'];
         // 순환하며 각 방에 몬스터를 배치하기 위한 인덱스
         this._roomIndex = 0;
     }

--- a/src/managers/item-ai-manager.js
+++ b/src/managers/item-ai-manager.js
@@ -37,6 +37,7 @@ export class ItemAIManager {
             this._handleArtifacts(ent);
             if (nearbyEnemies.length > 0) {
                 this._handleBuffItems(ent, entities);
+                this._handleAttackItems(ent, nearbyEnemies);
             }
         }
     }
@@ -146,6 +147,20 @@ export class ItemAIManager {
 
         if (!self.effects.some(e => e.id === item.effectId)) {
             this._useItem(self, item, self);
+        }
+    }
+
+    _handleAttackItems(self, enemies) {
+        const inventory = self.consumables || self.inventory;
+        if (!Array.isArray(inventory) || inventory.length === 0) return;
+
+        const item = inventory.find(i => i.tags?.includes('attack_item'));
+        if (!item || !item.effectId) return;
+
+        const range = item.range || self.attackRange || self.visionRange;
+        const target = enemies.find(e => Math.hypot(e.x - self.x, e.y - self.y) <= range);
+        if (target) {
+            this._useItem(self, item, target);
         }
     }
 

--- a/src/micro/WeaponAI.js
+++ b/src/micro/WeaponAI.js
@@ -200,6 +200,34 @@ export class MaceAI extends SwordAI {
     }
 }
 
+export class StunBatonAI extends MaceAI {
+    decideAction(wielder, weapon, context) {
+        const { enemies } = context;
+        if (!enemies || enemies.length === 0) return { type: 'idle' };
+
+        let nearest = null;
+        let minDist = Infinity;
+        for (const e of enemies) {
+            const d = Math.hypot(e.x - wielder.x, e.y - wielder.y);
+            if (d < minDist) { minDist = d; nearest = e; }
+        }
+
+        if (!nearest) return { type: 'idle' };
+
+        const skillId = 'thunder_strike';
+        if (
+            weapon?.weaponStats?.canUseSkill(skillId) &&
+            (wielder.skillCooldowns[skillId] || 0) <= 0 &&
+            minDist <= wielder.attackRange &&
+            wielder.attackCooldown === 0
+        ) {
+            return { type: 'weapon_skill', skillId, target: nearest };
+        }
+
+        return super.decideAction(wielder, weapon, context);
+    }
+}
+
 export class StaffAI extends BowAI {
     // 지능 수치가 높을수록 기본 공격 피해가 증가합니다.
     // 실제 피해 계산은 CombatCalculator에서 처리됩니다.

--- a/src/micro/WeaponStatManager.js
+++ b/src/micro/WeaponStatManager.js
@@ -1,4 +1,4 @@
-import { SwordAI, DaggerAI, BowAI, SpearAI, ViolinBowAI, EstocAI, AxeAI, MaceAI, StaffAI, ScytheAI, WhipAI } from './WeaponAI.js';
+import { SwordAI, DaggerAI, BowAI, SpearAI, ViolinBowAI, EstocAI, AxeAI, MaceAI, StaffAI, ScytheAI, WhipAI, StunBatonAI } from './WeaponAI.js';
 import { WEAPON_SKILLS } from '../data/weapon-skills.js';
 
 export class WeaponStatManager {
@@ -61,6 +61,7 @@ export class WeaponStatManager {
         if (itemId.includes('estoc')) return new EstocAI();
         // --- 신규 무기 AI 연결 ---
         if (itemId.includes('axe')) return new AxeAI();
+        if (itemId.includes('stun_baton')) return new StunBatonAI();
         if (itemId.includes('mace')) return new MaceAI();
         if (itemId.includes('staff')) return new StaffAI();
         if (itemId.includes('scythe')) return new ScytheAI();

--- a/src/utils/aquariumUtils.js
+++ b/src/utils/aquariumUtils.js
@@ -38,7 +38,7 @@ import { ITEMS } from '../data/items.js';
 
 // Precompute lists so random selection is fast
 export const ALL_WEAPON_IDS = [
-    'short_sword', 'long_bow', 'estoc', 'axe', 'mace', 'staff',
+    'short_sword', 'long_bow', 'estoc', 'axe', 'mace', 'stun_baton', 'staff',
     'spear', 'scythe', 'whip', 'dagger', 'violin_bow'
 ];
 

--- a/tests/unit/itemAiManager.test.js
+++ b/tests/unit/itemAiManager.test.js
@@ -40,4 +40,19 @@ describe('ItemAI', () => {
     assert.strictEqual(merc.equipment.weapon, null, 'weapon should not be equipped');
     assert.strictEqual(itemManager.items.length, 1, 'item should remain on ground');
   });
+
+  test('attack item used on nearby enemy', () => {
+    const factory = new CharacterFactory(assets);
+    const itemFactory = new ItemFactory(assets);
+    const eventManager = new EventManager();
+    const projectileManager = new ProjectileManager(eventManager, assets);
+    const itemAI = new ItemAIManager(eventManager, projectileManager, null, { addEffect(){} });
+    const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'warrior' });
+    const enemy = factory.create('monster', { x:1, y:0, tileSize:1, groupId:'m' });
+    const grenade = itemFactory.create('shock_grenade', 0,0,1);
+    merc.consumables = [grenade];
+    const context = { player:merc, mercenaryManager:{ mercenaries:[merc] }, monsterManager:{ monsters:[enemy] } };
+    itemAI.update(context);
+    assert.strictEqual(merc.consumables.length, 0, 'grenade consumed');
+  });
 });


### PR DESCRIPTION
## Summary
- spawn stun batons among aquarium loop weapons
- support new stun baton AI with thunder strike skill
- add thunder strike to weapon skills and apply shock on hit
- allow ItemAI to throw attack items at enemies
- add tests for attack item usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68651947c58c8327aeb0d6ae625b7b42