### PR TITLE
Improve TensorFlow battle prediction

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -19,6 +19,9 @@ class Entity {
         this.height = this.stats.get('sizeInTiles_h') * tileSize;
         this.hp = this.stats.get('maxHp');
         this.mp = this.stats.get('maxMp');
+        this.kills = 0;
+        this.damageDealt = 0;
+        this.damageTaken = 0;
         this.skills = [];
         this.skillCooldowns = {};
         this.attackCooldown = 0;
@@ -230,6 +233,7 @@ class Entity {
             damage -= blocked;
         }
         this.hp -= damage;
+        this.damageTaken += damage;
         if (this.hp < 0) this.hp = 0;
     }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -883,6 +883,9 @@ export class Game {
 
         // 피해량 계산 완료 이벤트를 받아 실제 피해 적용
         eventManager.subscribe('damage_calculated', (data) => {
+            if (data.attacker && data.attacker.damageDealt != null) {
+                data.attacker.damageDealt += data.damage;
+            }
             data.defender.takeDamage(data.damage);
             eventManager.publish('entity_damaged', { attacker: data.attacker, defender: data.defender, damage: data.damage });
             if (data.defender.hp <= 0) {
@@ -920,6 +923,7 @@ export class Game {
         // 죽음 이벤트가 발생하면 경험치 획득 및 애니메이션을 시작
         eventManager.subscribe('entity_death', (data) => {
             const { attacker, victim } = data;
+            if (attacker && attacker.kills != null) attacker.kills++;
 
             victim.isDying = true;
             this.vfxManager.addDeathAnimation(victim, 'explode');

--- a/src/managers/battleMemoryManager.js
+++ b/src/managers/battleMemoryManager.js
@@ -1,0 +1,17 @@
+export class BattleMemoryManager {
+    constructor(rlManager = null) {
+        this.rlManager = rlManager;
+        this.history = [];
+    }
+
+    init() {}
+
+    record({ features, winner }) {
+        this.history.push({ features, winner });
+        if (this.rlManager && typeof this.rlManager.record === 'function') {
+            this.rlManager.record({ features, winner });
+        }
+    }
+}
+
+export default BattleMemoryManager;

--- a/src/managers/battlePredictionManager.js
+++ b/src/managers/battlePredictionManager.js
@@ -1,0 +1,47 @@
+import { RLManager } from './rlManager.js';
+
+export class BattlePredictionManager {
+    constructor(rlManager = null) {
+        this.rlManager = rlManager || new RLManager(null);
+    }
+
+    async init(featureLength = 3) {
+        if (this.rlManager && typeof this.rlManager.init === 'function') {
+            await this.rlManager.init(featureLength);
+        }
+    }
+
+    buildFeatures(teamA, teamB) {
+        const sumStat = (units, stat) => units.reduce((acc, u) => {
+            if (u.stats && typeof u.stats.get === 'function') {
+                return acc + (u.stats.get(stat) || 0);
+            }
+            return acc + (u[stat] || 0);
+        }, 0);
+        const atkA = sumStat(teamA, 'attackPower');
+        const atkB = sumStat(teamB, 'attackPower');
+        const defA = sumStat(teamA, 'defense');
+        const defB = sumStat(teamB, 'defense');
+        const hpA = sumStat(teamA, 'maxHp');
+        const hpB = sumStat(teamB, 'maxHp');
+        return [atkA - atkB, defA - defB, hpA - hpB];
+    }
+
+    async predict(teamA, teamB) {
+        const features = this.buildFeatures(teamA, teamB);
+        let prediction = null;
+        if (this.rlManager && typeof this.rlManager.predict === 'function') {
+            try {
+                const res = await this.rlManager.predict(features);
+                if (Array.isArray(res) && res.length >= 2) {
+                    prediction = res[0] > res[1] ? 'player' : 'enemy';
+                }
+            } catch (err) {
+                console.warn('[BattlePredictionManager] prediction failed:', err);
+            }
+        }
+        return { prediction, features };
+    }
+}
+
+export default BattlePredictionManager;

--- a/src/managers/battleRecorder.js
+++ b/src/managers/battleRecorder.js
@@ -18,6 +18,13 @@ export class BattleRecorder {
             winner: null,
             survivors: 0,
         };
+        for (const u of [...playerUnits, ...enemyUnits]) {
+            if (u) {
+                u.kills = 0;
+                u.damageDealt = 0;
+                u.damageTaken = 0;
+            }
+        }
     }
 
     endBattle({ winner, survivors } = {}) {
@@ -29,8 +36,48 @@ export class BattleRecorder {
         const entries = Object.entries(this.current.killCounts);
         if (entries.length) {
             entries.sort((a, b) => b[1] - a[1]);
-            this.current.bestUnitId = parseInt(entries[0][0]);
-            this.current.worstUnitId = parseInt(entries[entries.length - 1][0]);
+        }
+
+        const allUnits = [...this.current.playerUnits, ...this.current.enemyUnits];
+        const calcSynergy = (unit, team) => {
+            const teammates = team.filter(t => t !== unit);
+            const myKeys = [];
+            for (const item of Object.values(unit.equipment || {})) {
+                if (item?.synergies) myKeys.push(...item.synergies);
+            }
+            const unique = [...new Set(myKeys)];
+            let score = 0;
+            for (const key of unique) {
+                if (teammates.some(t => Object.values(t.equipment || {}).some(it => it?.synergies?.includes(key)))) {
+                    score++;
+                }
+            }
+            return score;
+        };
+
+        let best = null;
+        let worst = null;
+        let bestScore = -Infinity;
+        let worstScore = Infinity;
+        for (const u of allUnits) {
+            const team = this.current.playerUnits.includes(u) ? this.current.playerUnits : this.current.enemyUnits;
+            const synergy = calcSynergy(u, team);
+            const kills = this.current.killCounts[u.id] || 0;
+            const dmgScore = (u.damageDealt || 0) - (u.damageTaken || 0) * 0.5;
+            const score = kills * 10 + synergy + dmgScore / 5;
+            if (score > bestScore) { bestScore = score; best = u; }
+            if (score < worstScore) { worstScore = score; worst = u; }
+        }
+
+        if (best) {
+            this.current.bestUnitId = best.id;
+            const s = calcSynergy(best, this.current.playerUnits.includes(best) ? this.current.playerUnits : this.current.enemyUnits);
+            this.current.bestReason = `kills:${this.current.killCounts[best.id] || 0}, synergy:${s}, dmg:${best.damageDealt}/${best.damageTaken}`;
+        }
+        if (worst) {
+            this.current.worstUnitId = worst.id;
+            const s = calcSynergy(worst, this.current.playerUnits.includes(worst) ? this.current.playerUnits : this.current.enemyUnits);
+            this.current.worstReason = `kills:${this.current.killCounts[worst.id] || 0}, synergy:${s}, dmg:${worst.damageDealt}/${worst.damageTaken}`;
         }
 
         const report = this.current;

--- a/tests/unit/rlObserver.test.js
+++ b/tests/unit/rlObserver.test.js
@@ -9,8 +9,8 @@ describe('RLObserver', () => {
         const mapStub = { width: 8, height: 6, tileSize: 1 };
         const observer = new RLObserver(ev, mapStub);
         await observer.init();
-        observer.rlManager.predict = async () => [0.7, 0.3];
-        observer.rlManager.record = () => {};
+        observer.predictionManager.rlManager.predict = async () => [0.7, 0.3];
+        observer.memoryManager.rlManager.record = () => {};
 
         const made = [];
         const results = [];


### PR DESCRIPTION
## Summary
- add BattlePredictionManager and BattleMemoryManager for TensorFlow logic
- update RLObserver to use the new managers
- track kills and damage on entities
- use damage info in game event handlers and BattleRecorder
- enhance MVP selection logic in BattleRecorder
- adjust RLObserver unit test

## Testing
- `npm test` *(fails: TensorFlow initialization issues)*

------
https://chatgpt.com/codex/tasks/task_e_6865223e62dc832780acb340c4f25d79