### PR TITLE
Revamp shock grenade AOE and effect cleanup

### DIFF
--- a/src/assetLoader.js
+++ b/src/assetLoader.js
@@ -59,6 +59,7 @@ export class AssetLoader {
     loadVfxImages() {
         const effects = [
             ['fire-nova-effect', 'assets/images/fire-nova-effect.png'],
+            ['shock-wave', 'assets/images/shock-wave.png'],
         ];
         effects.forEach(([key, src]) => this.loadImage(key, src));
     }

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -191,11 +191,11 @@ export const EFFECTS = {
     shock: {
         name: '감전',
         type: 'dot',
-        duration: 300,
+        duration: 120,
         damagePerTurn: 4,
-        tags: ['status_ailment', 'shock', 'dot'],
+        tags: ['status_ailment', 'shock', 'dot', 'cc'],
         overlayColor: 'rgba(230, 230, 50, 0.4)',
-        particle: { type: 'electric', color: 'yellow' }
+        particle: { type: 'electric', color: '#00aaff' }
     },
     burn: {
         name: '화상',

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -367,8 +367,9 @@ export const ITEMS = {
         name: '쇼크 그레네이드',
         type: 'consumable',
         tags: ['consumable', 'attack_item'],
-        imageKey: 'potion',
-        effectId: 'shock'
+        imageKey: 'shock-grenade',
+        effectId: 'shock',
+        aoeRadius: 128
     },
 
     // --- 룬 아이템 ---

--- a/src/factory.js
+++ b/src/factory.js
@@ -282,6 +282,7 @@ export class ItemFactory {
         }
         if (baseItem.healAmount) item.healAmount = baseItem.healAmount;
         if (baseItem.effectId) item.effectId = baseItem.effectId;
+        if (baseItem.aoeRadius) item.aoeRadius = baseItem.aoeRadius;
 
         if (item.type === 'weapon' || item.type === 'armor') {
             const numSockets = Math.floor(Math.random() * 4); // 0~3개 소켓

--- a/src/game.js
+++ b/src/game.js
@@ -110,6 +110,7 @@ export class Game {
         this.loader.loadImage('wall', 'assets/wall.png');
         this.loader.loadImage('gold', 'assets/gold.png');
         this.loader.loadImage('potion', 'assets/potion.png');
+        this.loader.loadImage('shock-grenade', 'assets/images/shock-grenade.png');
         this.loader.loadImage('sword', 'assets/images/shortsword.png');
         this.loader.loadWeaponImages();
         this.loader.loadImage('shield', 'assets/images/shield.png');

--- a/src/particle.js
+++ b/src/particle.js
@@ -3,6 +3,7 @@ export class Particle {
         this.x = x;
         this.y = y;
         this.color = color;
+        this.type = options.type || null;
 
         this.text = options.text || null;
 
@@ -18,6 +19,11 @@ export class Particle {
 
         this.homingTarget = options.homingTarget || null;
         this.homingStrength = options.homingStrength !== undefined ? options.homingStrength : 0.05;
+
+        if (this.type === 'electric') {
+            this.wobble = Math.random() * Math.PI * 2;
+            this.wobbleSpeed = 0.5 + Math.random() * 0.5;
+        }
     }
 
     update() {
@@ -34,6 +40,14 @@ export class Particle {
         this.vy += this.gravity;
         this.x += this.vx;
         this.y += this.vy;
+
+        if (this.type === 'electric') {
+            this.wobble += this.wobbleSpeed;
+            this.x += Math.sin(this.wobble) * 0.5;
+            this.y += Math.cos(this.wobble) * 0.5;
+            this.vx *= 0.98;
+            this.vy *= 0.98;
+        }
     }
 
     render(ctx) {
@@ -45,6 +59,13 @@ export class Particle {
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             ctx.fillText(this.text, this.x, this.y);
+        } else if (this.type === 'electric') {
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, this.size, 0, Math.PI * 2);
+            ctx.fillStyle = this.color;
+            ctx.shadowBlur = 10;
+            ctx.shadowColor = this.color;
+            ctx.fill();
         } else {
             ctx.fillStyle = this.color;
             ctx.fillRect(this.x, this.y, this.size, this.size);

--- a/tests/unit/effectManager.test.js
+++ b/tests/unit/effectManager.test.js
@@ -71,4 +71,15 @@ test('신속 이동 속도 증가', () => {
     assert.strictEqual(stats.get('movementSpeed'), base);
 });
 
+test('effects cleaned up on entity removal', () => {
+    const eventManager = new EventManager();
+    const removed = [];
+    const vfx = { removeEmitter:e=>removed.push(e), addEmitter:()=>({}) };
+    const effectManager = new EffectManager(eventManager, vfx);
+    const target = { id:'t', effects:[], stats:{ recalculate() {}, increaseBaseStat() {} } };
+    effectManager.addEffect(target, 'poison');
+    eventManager.publish('entity_removed', { victimId:'t' });
+    assert.strictEqual(removed.length, 1, 'emitter removed');
+});
+
 });

--- a/tests/unit/itemAiManager.test.js
+++ b/tests/unit/itemAiManager.test.js
@@ -55,4 +55,35 @@ describe('ItemAI', () => {
     itemAI.update(context);
     assert.strictEqual(merc.consumables.length, 0, 'grenade consumed');
   });
+
+  test('attack item not used on ally', () => {
+    const factory = new CharacterFactory(assets);
+    const itemFactory = new ItemFactory(assets);
+    const itemAI = new ItemAIManager();
+    itemAI.setEffectManager({ addEffect(){} });
+    const m1 = factory.create('monster', { x:0, y:0, tileSize:1, groupId:'m' });
+    const m2 = factory.create('monster', { x:1, y:0, tileSize:1, groupId:'m' });
+    const grenade = itemFactory.create('shock_grenade', 0,0,1);
+    m1.consumables = [grenade];
+    const context = { player:m1, mercenaryManager:{mercenaries:[]}, monsterManager:{monsters:[m1,m2]} };
+    itemAI.update(context);
+    assert.strictEqual(m1.consumables.length, 1, 'grenade not used on ally');
+  });
+
+  test('aoe attack item affects multiple enemies', () => {
+    const factory = new CharacterFactory(assets);
+    const itemFactory = new ItemFactory(assets);
+    const calls = [];
+    const itemAI = new ItemAIManager();
+    itemAI.setEffectManager({ addEffect:(t)=>calls.push(t) });
+    const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'warrior' });
+    const e1 = factory.create('monster', { x:1, y:0, tileSize:1, groupId:'m' });
+    const e2 = factory.create('monster', { x:2, y:0, tileSize:1, groupId:'m' });
+    const grenade = itemFactory.create('shock_grenade', 0,0,1);
+    merc.consumables = [grenade];
+    const context = { player:merc, mercenaryManager:{mercenaries:[merc]}, monsterManager:{monsters:[e1,e2]} };
+    itemAI.update(context);
+    assert.strictEqual(calls.length, 2, 'both enemies affected');
+    assert.strictEqual(merc.consumables.length, 0, 'grenade consumed');
+  });
 });


### PR DESCRIPTION
## Summary
- load new shock grenade and wave assets
- convert shock grenade to AOE item with updated icon
- rework shock status to briefly paralyze targets
- add electric particle effect type
- fix item AI enemy detection and handle AOE
- manage effect emitters on entity removal
- update factories and tests

## Testing
- `node tests/unit/itemAiManager.test.js`
- `node tests/unit/effectManager.test.js`
- `node run-tests.mjs` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6865f74fa6ac8327ae40d94c637c9069