### PR TITLE
Improve shock grenade effect timing

### DIFF
--- a/src/managers/item-ai-manager.js
+++ b/src/managers/item-ai-manager.js
@@ -162,6 +162,28 @@ export class ItemAIManager {
     _useItem(user, item, target, allEntities = []) {
         if (!item || (item.quantity && item.quantity <= 0)) return;
 
+        const onHit = () => this._applyItemHitEffects(user, item, target, allEntities);
+
+        if (this.projectileManager && user !== target) {
+            this.projectileManager.throwItem(user, target, item, 0, null, onHit);
+        } else {
+            onHit();
+        }
+
+        if (item.quantity > 1) {
+            item.quantity -= 1;
+        } else {
+            const inv = user.consumables || user.inventory;
+            const idx = inv.indexOf(item);
+            if (idx >= 0) inv.splice(idx, 1);
+        }
+
+        if (this.eventManager) {
+            this.eventManager.publish('log', { message: `${user.constructor.name} uses ${item.name}` });
+        }
+    }
+
+    _applyItemHitEffects(user, item, target, allEntities = []) {
         if (item.healAmount) {
             const heal = item.healAmount;
             target.hp = Math.min(target.maxHp, target.hp + heal);
@@ -191,22 +213,6 @@ export class ItemAIManager {
         if (this.vfxManager) {
             const scale = (item.type === 'artifact' || item.tags?.includes('artifact')) ? 0.33 : 1;
             this.vfxManager.addItemUseEffect(target, item.image, { scale });
-        }
-
-        if (this.projectileManager && user !== target) {
-            this.projectileManager.throwItem(user, target, item);
-        }
-
-        if (item.quantity > 1) {
-            item.quantity -= 1;
-        } else {
-            const inv = user.consumables || user.inventory;
-            const idx = inv.indexOf(item);
-            if (idx >= 0) inv.splice(idx, 1);
-        }
-
-        if (this.eventManager) {
-            this.eventManager.publish('log', { message: `${user.constructor.name} uses ${item.name}` });
         }
     }
 }

--- a/src/managers/projectileManager.js
+++ b/src/managers/projectileManager.js
@@ -42,7 +42,7 @@ export class ProjectileManager {
         }
     }
 
-    throwItem(caster, target, item, damage = 0, itemManager = null) {
+    throwItem(caster, target, item, damage = 0, itemManager = null, onHit = null) {
         const config = {
             x: caster.x + caster.width / 2,
             y: caster.y + caster.height / 2,
@@ -60,6 +60,7 @@ export class ProjectileManager {
         const projectile = new Projectile(config);
         projectile.droppedItem = item;
         projectile.itemManager = itemManager;
+        projectile.onHit = onHit;
         this.projectiles.push(projectile);
     }
 
@@ -103,6 +104,11 @@ export class ProjectileManager {
                             this.eventManager.publish('entity_attack', { attacker: proj.caster, defender: aoeTarget, damage: proj.damage * 0.5 });
                         }
                     }
+                }
+
+
+                if (typeof proj.onHit === 'function') {
+                    try { proj.onHit(proj, result.target); } catch (err) { console.warn('[ProjectileManager] onHit error', err); }
                 }
 
                 if (proj.droppedItem && proj.itemManager) {


### PR DESCRIPTION
## Summary
- support hit callbacks for projectiles
- delay item effects until projectiles collide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686626f450308327875708c0cdd49965