### PR TITLE
Implement tactical reinforcement learning features

### DIFF
--- a/src/managers/battlePredictionManager.js
+++ b/src/managers/battlePredictionManager.js
@@ -1,30 +1,88 @@
 import { RLManager } from './rlManager.js';
+import { MAP_WIDTH, MAP_HEIGHT } from '../constants/mapDimensions.js';
 
 export class BattlePredictionManager {
     constructor(rlManager = null) {
         this.rlManager = rlManager || new RLManager(null);
     }
 
-    async init(featureLength = 3) {
+    async init(featureLength = 12) {
         if (this.rlManager && typeof this.rlManager.init === 'function') {
             await this.rlManager.init(featureLength);
         }
     }
 
     buildFeatures(teamA, teamB) {
-        const sumStat = (units, stat) => units.reduce((acc, u) => {
-            if (u.stats && typeof u.stats.get === 'function') {
-                return acc + (u.stats.get(stat) || 0);
-            }
-            return acc + (u[stat] || 0);
-        }, 0);
-        const atkA = sumStat(teamA, 'attackPower');
-        const atkB = sumStat(teamB, 'attackPower');
-        const defA = sumStat(teamA, 'defense');
-        const defB = sumStat(teamB, 'defense');
-        const hpA = sumStat(teamA, 'maxHp');
-        const hpB = sumStat(teamB, 'maxHp');
-        return [atkA - atkB, defA - defB, hpA - hpB];
+        const statsA = this.calculateTeamStats(teamA);
+        const statsB = this.calculateTeamStats(teamB);
+
+        const compA = this.getUnitComposition(teamA);
+        const compB = this.getUnitComposition(teamB);
+
+        const cohesionA = this.calculateTeamCohesion(teamA);
+        const cohesionB = this.calculateTeamCohesion(teamB);
+
+        const center = { x: MAP_WIDTH / 2, y: MAP_HEIGHT / 2 };
+        const controlA = this.calculateCentralControl(teamA, center);
+        const controlB = this.calculateCentralControl(teamB, center);
+
+        return [
+            this.normalize(statsA.totalPower - statsB.totalPower, -1000, 1000),
+            this.normalize(statsA.totalHealth - statsB.totalHealth, -5000, 5000),
+            compA.melee, compA.ranged, compA.support,
+            compB.melee, compB.ranged, compB.support,
+            this.normalize(cohesionA, 0, 500),
+            this.normalize(cohesionB, 0, 500),
+            controlA,
+            controlB,
+        ];
+    }
+
+    calculateTeamStats(units) {
+        const sum = (stat) => units.reduce((acc, u) => acc + (u[stat] || 0), 0);
+        return {
+            totalPower: sum('attackPower') + sum('defense'),
+            totalHealth: sum('maxHp')
+        };
+    }
+
+    getUnitComposition(units) {
+        const counts = { melee: 0, ranged: 0, support: 0 };
+        for (const u of units) {
+            if (u.isRanged && u.isRanged()) counts.ranged += 1;
+            else if (u.isSupport && u.isSupport()) counts.support += 1;
+            else counts.melee += 1;
+        }
+        const total = units.length || 1;
+        return {
+            melee: counts.melee / total,
+            ranged: counts.ranged / total,
+            support: counts.support / total,
+        };
+    }
+
+    calculateTeamCohesion(units) {
+        if (units.length <= 1) return 0;
+        const center = this.calculateCenter(units);
+        const dists = units.map(u => Math.hypot(u.x - center.x, u.y - center.y));
+        const avg = dists.reduce((a, b) => a + b, 0) / dists.length;
+        return avg;
+    }
+
+    calculateCentralControl(units, center) {
+        if (units.length === 0) return 0;
+        const radius = 100;
+        const count = units.filter(u => Math.hypot(u.x - center.x, u.y - center.y) < radius).length;
+        return count / units.length;
+    }
+
+    calculateCenter(units) {
+        const sum = units.reduce((acc, u) => ({ x: acc.x + u.x, y: acc.y + u.y }), { x: 0, y: 0 });
+        return { x: sum.x / units.length, y: sum.y / units.length };
+    }
+
+    normalize(value, min, max) {
+        return (value - min) / (max - min);
     }
 
     async predict(teamA, teamB) {

--- a/src/managers/rlManager.js
+++ b/src/managers/rlManager.js
@@ -7,6 +7,7 @@ export class RLManager {
         this.eventManager = eventManager;
         this.worker = null;
         this.ready = false;
+        this.lastActionIndex = null;
     }
 
     async init(featLength = 3) {
@@ -40,6 +41,15 @@ export class RLManager {
             this.worker.addEventListener('message', handler);
             this.worker.postMessage({ type: 'predict', id, data: features });
         });
+    }
+
+    recordExperience(exp) {
+        if (!this.ready || !this.worker) return;
+        this.worker.postMessage({ type: 'train', experience: exp });
+    }
+
+    getLastAction() {
+        return this.lastActionIndex;
     }
 
     // backward compatibility

--- a/src/workers/rlWorker.js
+++ b/src/workers/rlWorker.js
@@ -3,7 +3,7 @@ importScripts('https://cdn.jsdelivr.net/npm/@tensorflow/tfjs');
 let tf = self.tf;
 let model = null;
 let dataset = []; // 학습 데이터를 저장할 배열
-let featureLength = 6; // 기본 특성 길이
+let featureLength = 12; // 기본 특성 길이
 
 /**
  * AI 모델을 초기화합니다.
@@ -84,6 +84,13 @@ async function handleMessage(e) {
                 postMessage({ type: 'prediction', id, prediction: Array.from(prediction) });
             } else {
                 postMessage({ type: 'prediction', id, prediction: null });
+            }
+            break;
+        case 'train':
+            if (e.data.experience) {
+                const exp = e.data.experience;
+                dataset.push({ input: exp.state, output: [exp.reward, 0] });
+                if (dataset.length % 20 === 0) await trainModel();
             }
             break;
         case 'save':


### PR DESCRIPTION
## Summary
- add group-level tactics (pincer, shield wall, focus fire) to `MetaAIManager`
- expand `BattlePredictionManager` with richer state vectors
- initialize RL components with new feature length and provide reward tracking via `RLObserver`
- allow `RLManager` to pass training experiences to `rlWorker`
- enable training messages in `rlWorker`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686632faa4d883278570e5b0c7f4fa91