### PR TITLE
Improve shock grenade logic

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -453,6 +453,7 @@ export class Item {
 
 export class Projectile {
     constructor(config) {
+        this.id = Math.random().toString(36).slice(2);
         this.x = config.x;
         this.y = config.y;
         // 처음 생성된 위치를 저장해 궤적을 그릴 때 사용한다
@@ -467,6 +468,8 @@ export class Projectile {
         this.damage = config.damage;
         this.knockbackStrength = config.knockbackStrength || 0;
         this.caster = config.caster;
+        this.isFriendly = config.isFriendly ?? config.caster?.isFriendly;
+        this.unitType = 'projectile';
         // 밝게 그려야 하는 마법 투사체의 경우 blendMode를 'lighter'로 설정할 수 있다
         this.blendMode = config.blendMode || null;
 

--- a/src/game.js
+++ b/src/game.js
@@ -1439,18 +1439,23 @@ export class Game {
     }
 
     update = (deltaTime) => {
-        if (this.gameState.currentState === 'WORLD') {
+        const { gameState, mercenaryManager, monsterManager, itemManager, mapManager, inputHandler, effectManager, turnManager, metaAIManager, eventManager, equipmentManager, pathfindingManager, microEngine, microItemAIManager } = this;
+        const commonEntities = [gameState.player, ...mercenaryManager.mercenaries, ...(this.petManager?.pets || [])];
+
+        if (gameState.currentState === 'WORLD') {
             this.worldEngine.update();
+            effectManager.update(commonEntities);
             return;
-        } else if (this.gameState.currentState === 'FORMATION_SETUP') {
+        } else if (gameState.currentState === 'FORMATION_SETUP') {
+            effectManager.update(commonEntities);
             return;
-        } else if (this.gameState.currentState !== 'COMBAT') {
+        } else if (gameState.currentState !== 'COMBAT') {
+            effectManager.update(commonEntities);
             return;
         }
 
         this.handleCameraReset();
 
-        const { gameState, mercenaryManager, monsterManager, itemManager, mapManager, inputHandler, effectManager, turnManager, metaAIManager, eventManager, equipmentManager, pathfindingManager, microEngine, microItemAIManager } = this;
         if (gameState.isPaused || gameState.isGameOver) return;
 
         const allEntities = [gameState.player, ...mercenaryManager.mercenaries, ...monsterManager.monsters, ...(this.petManager?.pets || [])];


### PR DESCRIPTION
## Summary
- let projectiles mark allegiance and emit events when hitting
- apply consumable effects from the projectile itself
- keep status effects updating outside combat to clear particles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686626f450308327875708c0cdd49965