### PR TITLE
Add RL MVP display

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 * **평판 시스템 토글:** `config/gameSettings.js`의 `ENABLE_REPUTATION_SYSTEM` 값을 false로 설정하면 평판 기록과 모델 로드를 생략하여 성능을 높일 수 있습니다.
 * **실시간 학습 매니저:** `RLManager`가 전투 로그를 Web Worker로 전송해 TensorFlow 모델을 실시간으로 학습하며 예측 기능을 제공합니다.
 * **TensorFlow 입력 매니저:** `RLInputManager`가 학습된 모델의 예측을 받아 AI의 행동 결정에 반영합니다.
+* **승자 예측 & MVP 표기:** 수족관 루프 전투마다 TensorFlow가 승자를 예측하고, 가장 활약한 유닛과 부진한 유닛을 UI에 표시합니다.
 
 ## 개발 원칙
 

--- a/src/events/aquariumLoopAuto.js
+++ b/src/events/aquariumLoopAuto.js
@@ -35,7 +35,11 @@ export function startAquariumBattleLoop(game, { rounds = Infinity, onRoundComple
         resetEntities();
         const info = startAquariumLoopTest(game);
         eventManager.publish('battle_round_start', { round: currentRound + 1, playerInfo: info.playerInfo, enemyInfo: info.enemyInfo });
-        game.battleRecorder.startBattle(info.playerInfo, info.enemyInfo);
+        // Pass actual entity instances so damage와 kill 기록이 반영됩니다.
+        game.battleRecorder.startBattle(
+            mercenaryManager.mercenaries,
+            monsterManager.monsters
+        );
         running = true;
         currentRound++;
     }

--- a/src/managers/rlUIManager.js
+++ b/src/managers/rlUIManager.js
@@ -23,12 +23,15 @@ export class RLUIManager {
         this.historyEl.prepend(div);
     }
 
-    update({ round, prediction, actual, correct, accuracy, score }) {
+    update({ round, prediction, actual, correct, accuracy, score, bestName, worstName }) {
         if (!this.panel) return;
         this.accuracyEl.textContent = `적중률: ${accuracy.toFixed(1)}%`;
         this.scoreEl.textContent = `잘했어요 점수: ${score}`;
         const div = document.createElement('div');
-        div.textContent = `라운드 ${round} 결과: ${prediction}→${actual} ${correct ? '✅' : '❌'}`;
+        let text = `라운드 ${round} 결과: ${prediction}→${actual} ${correct ? '✅' : '❌'}`;
+        if (bestName) text += ` | ⭐ ${bestName}`;
+        if (worstName) text += ` | 😞 ${worstName}`;
+        div.textContent = text;
         this.historyEl.prepend(div);
     }
 }

--- a/tests/unit/rlObserver.test.js
+++ b/tests/unit/rlObserver.test.js
@@ -17,9 +17,18 @@ describe('RLObserver', () => {
         ev.subscribe('rl_prediction_made', (d) => made.push(d));
         ev.subscribe('rl_prediction_result', (d) => results.push(d));
 
-        ev.publish('battle_round_start', { round: 1, playerInfo: [{}], enemyInfo: [{}] });
+        ev.publish('battle_round_start', { round: 1, playerInfo: [{ id: 1, name: 'A' }], enemyInfo: [{ id: 2, name: 'B' }] });
         await observer.predictionPromise;
-        ev.publish('battle_round_complete', { round: 1, winner: FACTIONS.PLAYER, playerUnits: [{}], enemyUnits: [{}] });
+        ev.publish('battle_round_complete', {
+            round: 1,
+            winner: FACTIONS.PLAYER,
+            playerUnits: [{ id: 1, name: 'A' }],
+            enemyUnits: [{ id: 2, name: 'B' }],
+            bestUnitId: 1,
+            worstUnitId: 2,
+            bestReason: 'x',
+            worstReason: 'y'
+        });
         await observer.roundCompletePromise;
 
         assert.strictEqual(observer.stats.correct, 1);
@@ -28,5 +37,7 @@ describe('RLObserver', () => {
         assert.strictEqual(made.length, 1);
         assert.strictEqual(results.length, 1);
         assert.strictEqual(results[0].correct, true);
+        assert.strictEqual(results[0].bestName, 'A');
+        assert.strictEqual(results[0].worstName, 'B');
     });
 });


### PR DESCRIPTION
## Summary
- record aquarium loop battles using actual entities
- publish best/worst unit info from RLObserver
- show MVP info in RL UI
- document TensorFlow MVP display in README
- update unit test for RLObserver

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68664d0c0b888327b61a39e4b1c069f7