### PR TITLE
Reduce debug log overhead

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -33,4 +33,8 @@ export const SETTINGS = {
     GUIDELINE_REPO_URL: "cagecorn/doom-crawler-newest/contents/TensorFlow%27s%20room?ref=main",
     // 이동 속도는 StatManager의 'movement' 스탯으로부터 파생됩니다.
     // ... 나중에 더 많은 설정 추가
+
+    // 디버그 로그 출력 여부를 제어합니다. 로그가 많을 경우 프레임 저하가
+    // 발생할 수 있으므로 기본값을 false로 둡니다.
+    ENABLE_DEBUG_LOGS: false
 };

--- a/src/game.js
+++ b/src/game.js
@@ -1462,7 +1462,9 @@ export class Game {
         if (this.auraManager) {
             this.auraManager.update(allEntities);
         }
-        eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update Start ---' });
+        if (SETTINGS.ENABLE_DEBUG_LOGS) {
+            eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update Start ---' });
+        }
         const player = gameState.player;
         if (player.attackCooldown > 0) player.attackCooldown--;
         let moveX = 0, moveY = 0;
@@ -1571,7 +1573,9 @@ export class Game {
             ...this.monsterManager.monsters.flatMap(m => m.consumables || []),
         ];
         this.microEngine.update(allItems);
-        eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update End ---' });
+        if (SETTINGS.ENABLE_DEBUG_LOGS) {
+            eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update End ---' });
+        }
     }
 
     render = () => {

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -198,10 +198,12 @@ export class MetaAIManager {
         // 간단한 쿨다운 메커니즘으로 빈도를 제한한다.
         if (!entity._aiLogCooldown) entity._aiLogCooldown = 0;
         if (entity._aiLogCooldown <= 0) {
-            eventManager.publish('debug', {
-                tag: 'AI',
-                message: `${entity.constructor.name} (id: ${entity.id.substr(0,4)}) decided action: ${action.type}`
-            });
+            if (SETTINGS.ENABLE_DEBUG_LOGS) {
+                eventManager.publish('debug', {
+                    tag: 'AI',
+                    message: `${entity.constructor.name} (id: ${entity.id.substr(0,4)}) decided action: ${action.type}`
+                });
+            }
             entity._aiLogCooldown = 30; // 약 0.5초(60fps 기준) 동안 로그 억제
         } else {
             entity._aiLogCooldown--;


### PR DESCRIPTION
## Summary
- add ENABLE_DEBUG_LOGS setting
- wrap frame debug events in a setting check
- only publish AI debug logs when debugging is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686664e9e32c832795c002f5cfe8efbb