### PR TITLE
Remove affixes from attack items

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -292,8 +292,11 @@ export class ItemFactory {
             item.sockets = [];
         }
 
-        if (Math.random() < 0.5) this._applyAffix(item, PREFIXES, 'prefix');
-        if (Math.random() < 0.5) this._applyAffix(item, SUFFIXES, 'suffix');
+        const isAttackItem = item.tags.includes('attack_item');
+        if (!isAttackItem) {
+            if (Math.random() < 0.5) this._applyAffix(item, PREFIXES, 'prefix');
+            if (Math.random() < 0.5) this._applyAffix(item, SUFFIXES, 'suffix');
+        }
 
         if (baseItem.possessionAI) {
             item.possessionAI = baseItem.possessionAI;


### PR DESCRIPTION
## Summary
- prevent attack items such as Shock Grenade from receiving stat affixes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68666540864c8327a77c2db98422d1b3