### PR TITLE
Fix skeleton minion grouping

### DIFF
--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -44,9 +44,10 @@ export class MonsterManager {
     addMonster(monster) {
         this.monsters.push(monster);
         if (this.metaAIManager) {
+            const targetGroupId = monster.groupId || 'dungeon_monsters';
             const group =
-                this.metaAIManager.groups['dungeon_monsters'] ||
-                this.metaAIManager.createGroup('dungeon_monsters');
+                this.metaAIManager.groups[targetGroupId] ||
+                this.metaAIManager.createGroup(targetGroupId);
             group.addMember(monster);
         }
     }

--- a/src/managers/skillManager.js
+++ b/src/managers/skillManager.js
@@ -116,6 +116,12 @@ export class SkillManager {
         });
         monster.isFriendly = caster.isFriendly;
         monster.properties.summonedBy = caster.id;
+        if (Array.isArray(caster.minions)) {
+            caster.minions.push(monster);
+        } else {
+            caster.minions = [monster];
+        }
+
         if (this.monsterManager) {
             this.monsterManager.addMonster(monster);
         } else if (this.metaAIManager) {

--- a/tests/unit/summonSkeletonGroup.test.js
+++ b/tests/unit/summonSkeletonGroup.test.js
@@ -1,0 +1,31 @@
+import { CharacterFactory } from '../../src/factory.js';
+import { MonsterManager } from '../../src/managers/monsterManager.js';
+import { SkillManager } from '../../src/managers/skillManager.js';
+import { MetaAIManager } from '../../src/managers/ai-managers.js';
+import { EventManager } from '../../src/managers/eventManager.js';
+import { SKILLS } from '../../src/data/skills.js';
+import { describe, test, assert } from '../helpers.js';
+
+const assets = { skeleton:{} };
+
+describe('Summon Skeleton Group', () => {
+  test('summoned skeleton joins caster group and minion list', () => {
+    const factory = new CharacterFactory(assets);
+    const eventManager = new EventManager();
+    const monsterManager = new MonsterManager(eventManager, assets, factory);
+    const metaAI = new MetaAIManager(eventManager);
+    monsterManager.setMetaAIManager(metaAI);
+    const skillMgr = new SkillManager(eventManager);
+    skillMgr.setManagers({addEffect(){}}, factory, metaAI, monsterManager);
+
+    const caster = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'summoner', image:null });
+    metaAI.createGroup('g');
+
+    skillMgr.applySkillEffects(caster, SKILLS.summon_skeleton);
+
+    assert.strictEqual(monsterManager.monsters.length, 1);
+    const skeleton = monsterManager.monsters[0];
+    assert.ok(metaAI.groups['g'].members.includes(skeleton));
+    assert.ok(Array.isArray(caster.minions) && caster.minions.includes(skeleton));
+  });
+});


### PR DESCRIPTION
## Summary
- ensure monsters are added to their configured group
- track summoned skeletons in the summoner's minion list
- test that summoned skeleton joins summoner group

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68666f63a2b08327a070bfe6220853ad